### PR TITLE
Explicit Resource Type

### DIFF
--- a/src/provider.py
+++ b/src/provider.py
@@ -1,9 +1,15 @@
 import os
 import logging
-import cfn_custom_provider
+from . import cfn_custom_provider
 
 logging.basicConfig(level=os.getenv('LOG_LEVEL', 'INFO'))
 
 
 def handler(request, context):
-    return cfn_custom_provider.handler(request, context)
+    # Modify this value to support a custom Custom:: tag
+    # Add elif conditions (and additional cfn_*_provider files to support multiple tags
+    # see binxio/cfn-certificate-provider for an example
+    if request["ResourceType"] == "Custom::Custom":
+        return cfn_custom_provider.handler(request, context)
+    else:
+        raise ValueError(f'No handler found for custom resource {request["ResourceType"]}')


### PR DESCRIPTION
This PR makes the resource type explicit by importing the framework for resource types from `cfn-certificate-provider`, but defaulting to the backwards-compatible `Custom::Custom`.  Unlike `cfn-certificate-provider` (which has a provider in the `else`), I have added an explicit error branch.  I'm not sure if there's a compelling reason to not do this, but a typo in the Custom Resource name could land the user in the `else` branch.  If this is another provider, it could produce strange errors (e.g. parameters missing or even building wrong resources).

While I was in the file, I also changed the import strategy for providers.  This ensures that IDEs understand the imports even if they're nested in projects with different source roots.  I did this for a while to use a custom modification while it was PR'd.