### PR TITLE
Inline Documentation

### DIFF
--- a/src/cfn_custom_provider.py
+++ b/src/cfn_custom_provider.py
@@ -9,7 +9,7 @@ request_schema = {
     "properties": {
         "Value": {
             "type": "string",
-            # "minimum": 0, maximum: 1,  # "integer" type only
+            # "minimum": 0, "maximum": 1,  # "integer" type only
             # "default": "",  # use python natives for "integer" and "boolean" types
             "description": "this value will be made accessible through  Fn::GetAtt, property 'Value'",
         }

--- a/src/cfn_custom_provider.py
+++ b/src/cfn_custom_provider.py
@@ -9,6 +9,8 @@ request_schema = {
     "properties": {
         "Value": {
             "type": "string",
+            # "minimum": 0, maximum: 1,  # "integer" type only
+            # "default": "",  # use python natives for "integer" and "boolean" types
             "description": "this value will be made accessible through  Fn::GetAtt, property 'Value'",
         }
     },
@@ -24,16 +26,26 @@ class CustomProvider(ResourceProvider):
         self.heuristic_convert_property_types(self.properties)
 
     def create(self):
+        """Create the requested object and set a Resource ID.  See `update` for behaviors based on Resource ID."""
         value = self.get("Value")
         self.set_attribute("Value", value)
+        # ARNs and IDs are ideal
         self.physical_resource_id = value
 
     def update(self):
+        """Perform one of two update operations:
+
+        1. In-place Update:  Make an update without changing the Resource ID.  On success, the new Resource is used.
+           On failure, `update` is called again with the original parameters.
+        2. Replacement:  Create a new object and return a new Resource ID.  On success, `delete` is called with the old
+           Resource ID.  On failure, `delete` is called with the new Resource ID.
+        """
         value = self.get("Value")
         self.set_attribute("Value", value)
         self.physical_resource_id = value
 
     def delete(self):
+        """Remove the object indicated by the Resource ID."""
         self.success("nothing to do")
 
 


### PR DESCRIPTION
This PR inlines some documentation to assist new users (i.e. those most likely to be depending on a template) in developing well-behaved Custom Resources.  As someone who recently learned Custom Resources, the correct `update` behavior is especially non-obvious.  I also grabbed more of the structure from `cfn-resource-provider` to reduce the need to cross packages to figure it out.